### PR TITLE
Update AT_SIM7020E.h

### DIFF
--- a/src/AT_SIM7020E.h
+++ b/src/AT_SIM7020E.h
@@ -35,7 +35,7 @@ Author: Device Innovation team
 Create Date: 2 January 2020. 
 Modified: 19 May 2021.
 */
-
+#pragma once
 #include <Arduino.h>
 #include <Stream.h>
 


### PR DESCRIPTION
Add #pragma once at the top of library to make both "Magellan_SIM7020E.h" and  "AIS_SIM7020E_API.h" be called at the same time.
This prevent these errors\: " errors : redefinition of 'struct pingRESP' ..